### PR TITLE
New matchers and new options_for function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Fame is a framework for metamodelling in Python.
 - Models have fields, derived fields and constraints
 - Entities can have custom fields
 - Entities can be created even if data is invalid
-- There are functions to validate and get all errors
+- There are functions to validate and get error messages
 - Validation checks presence and type of fields
 - Validation checks all constraints
 - Derived fields are memoized
@@ -41,10 +41,10 @@ Example
 
 Conventions
 
-    - Define metamodel function first
-    - Then define derived field functions
-    - Then define all the constraint functions
-    - Constraint functions are all named "constraint", that is intentional
+- Define metamodel function first
+- Then define derived field functions
+- Then define all the constraint functions
+- Constraint functions are all named "constraint", that is intentional
 
 
 ## Installation

--- a/fame/__init__.py
+++ b/fame/__init__.py
@@ -7,6 +7,8 @@ from matchers import ArrayMatcher as array
 from matchers import NullableMatcher as nullable
 from matchers import OptionsMatcher as options
 from matchers import RegularExpressionMatcher as regexp
+from matchers import AnythingMatcher as anything
+from matchers import ReservedMatcher as reserved
 
 del model
 del matchers

--- a/fame/matchers.py
+++ b/fame/matchers.py
@@ -47,13 +47,13 @@ class NullableMatcher(object):
 class OptionsMatcher(object):
 
     def __init__(self, *strings):
-        self.strings = strings
+        self.options = strings
 
     def __call__(self, value):
-        return value in self.strings
+        return value in self.options
 
     def __str__(self):
-        return "options{}".format(self.strings)
+        return "options{}".format(self.options)
 
 
 class RegularExpressionMatcher(object):
@@ -67,4 +67,22 @@ class RegularExpressionMatcher(object):
 
     def __str__(self):
         return "regexp({})".format(self.regexp.pattern)
+
+
+class AnythingMatcher(object):
+
+    def __call__(self, value):
+        return True
+
+    def __str__(self):
+        return 'anything'
+
+
+class ReservedMatcher(object):
+
+    def __call__(self, value):
+        return False
+
+    def __str__(self):
+        return 'reserved'
 

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,24 @@ except:
 setup(
     name = 'fame',
     packages = ['fame'],
-    version = '1.1.1',
+    version = '1.2.0',
     description = 'A little language for schema-enforced models.',
     long_description = long_description,
     author = 'Adrian Kuhn',
     author_email = 'akuhnplus@gmail.com',
     url = 'https://github.com/akuhn/py-fame',
 )
+
+
+# Change log
+#
+# 1.2.0
+#
+# - Fix metamodel class property, Example.metamodel
+# - New class method, Example.options_for(field_name)
+# - New type matcher, anything
+# - New type matcher, reserved
+#
+# Prehistory starts here...
+#
+#

--- a/tests/test__model.py
+++ b/tests/test__model.py
@@ -82,7 +82,7 @@ def test____should_validate_model():
         whatnot='gibberish',
     )
 
-    expect(m.error_messages()).to(be_empty)
+    expect(list(m.error_messages())).to(be_empty)
     expect(m.is_valid()).to(be_true)
 
 
@@ -108,7 +108,7 @@ def test____should_get_fields_as_items():
 
 def test___should_not_validate():
     m = Example(name='button_color', percent_exposed=200, design=False)
-    errors = m.error_messages()
+    errors = list(m.error_messages())
 
     expect(m.is_valid()).to_not(be_true)
     expect(errors).to(contain(end_with("expected percent_exposed to not exceed 100, got 200")))
@@ -120,8 +120,9 @@ def test___should_not_validate():
 
 def test____should_automagically_match_unicode():
     m = Example(name=u'gibberish', subject=u'user', treatments=[])
+    errors = list(m.error_messages())
 
-    expect(m.error_messages()).to(be_empty)
+    expect(errors).to(be_empty)
     expect(m.is_valid()).to(be_true)
 
 
@@ -172,19 +173,12 @@ def test____should_memoize_derived_fields():
 
 def test____should_be_broken():
     m = Broken()
-    errors = m.error_messages()
+    errors = list(m.error_messages())
 
     expect(m.metamodel.constraints).to(have_length(2))
     expect(errors).to(contain(end_with("exepected to not return False")))
     expect(errors).to(contain(end_with("exepected to not return foo and bar")))
     expect(errors).to(have_length(2))
-
-
-def test____should_match_regexp():
-    m = Example(name='button_color', subject='user', treatments=[], design='http://example.com')
-
-    expect(m.error_messages()).to(be_empty)
-    expect(m.is_valid()).to(be_true)
 
 
 def test____should_not_match_regexp():
@@ -201,4 +195,17 @@ def test____number_should_not_match_regexp():
     expect(m.error_messages()).to(contain(end_with(
         "expected field 'design' to be nullable(regexp(^https?://)), got 9000"
     )))
+
+
+def test____should_have_options_for():
+    options = ('user', 'visitor', 'email', 'listing', 'market')
+
+    expect(Example.options_for('subject')).to(equal(options))
+
+
+def test____should_have_metamodel():
+    m = Example()
+
+    expect(Example).to(have_property('metamodel'))
+    expect(Example.metamodel).to(equal(m.metamodel))
 


### PR DESCRIPTION
A bunch of changes to model and metamodel

- Comment the uncommon double trigger of the `@schema` and `@constraint` decorators.
- Also, clarified methods names in metamodel class to align with language in the comments.
- Also, don’t bypass `get_value` in error messages function and as a result of that simplify away the `match` method in the filed class which is no longer needed as a wrapper around the type matchers, since `get_value` will take care of default values for us now.
- Also, extract error message prefix into a function to avoid creating excess objects when there are no errors.
- Also, add `anything` and `reserved` types.
- Also, rename options to `options`.

Test plan
- Run `python $(which nosetests) tests`
- Expect all tests to pass